### PR TITLE
Build a picocom container image

### DIFF
--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -1,0 +1,66 @@
+name: Build container image
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - Containerfile
+  push:
+    branches: [main]
+    # Publish semver tags as releases.
+    tags: ['v*.*.*']
+
+env:
+  # Use docker.io for Docker Hub if empty
+  REGISTRY: ghcr.io
+  # github.repository as <account>/<repo>
+  IMAGE_NAME: ${{ github.repository }}
+
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      # Login against a Docker registry except on PR
+      # https://github.com/docker/login-action
+      - name: Log into registry ${{ env.REGISTRY }}
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Extract metadata (tags, labels) for Docker
+      # https://github.com/docker/metadata-action
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=semver,pattern=v{{version}}
+            type=semver,pattern=v{{major}}.{{minor}}
+            type=semver,pattern=v{{major}}
+            type=ref,event=branch
+            type=ref,event=pr
+            type=sha
+
+      # Build and push Docker image with Buildx (don't push on PR)
+      # https://github.com/docker/build-push-action
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          file: Containerfile
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/smoketest.yaml
+++ b/.github/workflows/smoketest.yaml
@@ -1,8 +1,16 @@
 name: Smoke tests
 on:
   pull_request:
+    paths:
+      - "**.[ch]"
+      - Makefile
+      - "**.bats"
   push:
     branches-ignore: main
+    paths:
+      - "**.[ch]"
+      - Makefile
+      - "**.bats"
 
 permissions:
   contents: read

--- a/.github/workflows/unittest.yaml
+++ b/.github/workflows/unittest.yaml
@@ -1,8 +1,14 @@
 name: Unit tests
 on:
   pull_request:
+    paths:
+      - "**.[ch]"
+      - Makefile
   push:
     branches-ignore: main
+    paths:
+      - "**.[ch]"
+      - Makefile
 
 jobs:
   run-tests-linux:

--- a/Containerfile
+++ b/Containerfile
@@ -1,0 +1,18 @@
+FROM docker.io/alpine:3 AS builder
+
+RUN apk add alpine-sdk \
+    confuse \
+    confuse-dev \
+    check \
+    check-dev \
+    linux-headers
+
+WORKDIR /src
+COPY . /src
+RUN make realclean test && make realclean all
+
+FROM docker.io/alpine:3
+
+RUN apk add confuse
+COPY --from=builder /src/picocom /usr/local/bin/picocom
+ENTRYPOINT ["/usr/local/bin/picocom"]

--- a/README.md
+++ b/README.md
@@ -50,7 +50,9 @@ Please feel free to send comments, requests for new features (no
 promises, though!), bug-fixes and rants, to the author's email
 address shown at the top of this file.
 
-## Compilation / Installation
+## Installing picocom
+
+### Building from source
 
 Change into picocom's source directory and say:
 
@@ -94,6 +96,30 @@ system. For example:
 
 Alternatively, you might have to make some trivial edits to the
 Makefile for it to work with your system's make(1) command.
+
+### Using the container image
+
+You can run Picocom from the [official container image]. If you have
+[Podman] running in rootless mode, and you want to access port
+`/dev/ttyUSB2` at 115200 bps, you would run:
+
+[podman]: https://podman.io
+[official container image]: https://github.com/orgs/picocom-ng/packages?repo_name=picocom
+
+```
+podman run --rm -it --device /dev/ttyUSB2 --group-add keep-groups \
+  ghcr.io/picocom-ng/picocom:latest -b 115200 /dev/ttyUSB2
+```
+
+If you are running Podman as root:
+
+```
+podman run --rm -it --device /dev/ttyUSB2 \
+  ghcr.io/picocom-ng/picocom:latest -b 115200 /dev/ttyUSB2
+```
+
+And if you're running Docker, just replace `podman` in the above
+command line with `docker`.
 
 ## Using picocom
 


### PR DESCRIPTION
Build an official container image for picocom. You can use it like this:

    podman run -it --rm --device /dev/ttyUSB2 \
      --group-add keep-groups picocom -b 115200 /dev/ttyUSB2

The `--group-add keep-groups` is necessary if access to your serial devices requires particular group membership (e.g. in the common "dialout" or "uucp" groups).