### PR TITLE
Two typo fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ command line with `docker`.
 
 ## Using picocom
 
-If your computer is a PC and has the standard on-board RS-233 ports
+If your computer is a PC and has the standard on-board RS-232 ports
 (usually accessible as two male DB9 connectors at the back) then under
 Linux these are accessed through device nodes most likely named:
 `/dev/ttyS0` and `/dev/ttyS1`. If your computer has no on-board serial

--- a/picocom.c
+++ b/picocom.c
@@ -706,7 +706,7 @@ do_map (char *b, int map, char c)
         }
         break;
     case '\x08':
-        /* BS ma-pings */
+        /* BS mappings */
         if ( map & M_BSDEL ) {
             b[0] = '\x7f'; n = 1;
         }


### PR DESCRIPTION
I want to give up my picocom fork in favor of picocom-ng. Start syncing these two by applying two typo fixes from my fork.