### PR TITLE
Fix -T (short --tx-delay) not recognized and building on macOS

### DIFF
--- a/Makefile.macos
+++ b/Makefile.macos
@@ -1,0 +1,4 @@
+CPPFLAGS=-I/usr/local/include -I/opt/homebrew/include
+LDFLAGS=-L/usr/local/lib -L/opt/homebrew/lib
+LDLIBS=-lutil
+include Makefile

--- a/picocom.c
+++ b/picocom.c
@@ -1727,7 +1727,7 @@ parse_args(int argc, char *argv[])
         /* no default error messages printed. */
         opterr = 0;
 
-        c = getopt_long(argc, argv, "hirulcqXnv:s:r:e:f:b:y:d:p:g:t:x:",
+        c = getopt_long(argc, argv, "hirulcqXnv:s:r:e:f:b:y:d:p:g:t:x:T:",
                         longOptions, &optionIndex);
 
         if (c < 0)


### PR DESCRIPTION
This fixes the short form of --tx-delay command argument (-T) not being recognized and also makes it possible to compile on macOS by supporting homebrew which also solves #5